### PR TITLE
Added missing nodejs-npm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 MAINTAINER https://github.com/mozilla/observatory-cli
 
 RUN adduser -h /home/observatory -g "Observatory CLI User" -s /bin/ash -D observatory
-RUN apk --update add nodejs && \
+RUN apk --update add nodejs nodejs-npm && \
   rm -rf /var/cache/apk/* && \
   npm install -g observatory-cli
 


### PR DESCRIPTION
Hi,

Your Dockerfile is not working anymore, as the `npm` command is no longer found. It can now be found in the other package `nodejs-npm`.

This PR simply adds that package to `apk add` so that it works again.

Cheers,
fred