### PR TITLE
Fix report URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Score Description
 Score: 65 (modified due to --skip)
 Grade: C+
 
-Full Report Url: https://observatory.mozilla.org/analyze.html?host=some.site
+Full Report Url: https://observatory.mozilla.org/analyze/some.site
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ function formatAnswersCsv(scores, url, scan, options) {
     console.log(sprintf("%5f %s  %s.", score.score_modifier, fmt(padright(score.name, longest)), firstSentence));
   });
 
-  var fullReportUrl = "https://observatory.mozilla.org/analyze.html?host=" + options.site;
+  var fullReportUrl = "https://observatory.mozilla.org/analyze/" + options.site;
 
   if (Object.keys(options.skip).length) {
     console.log("\nScore: %s (modified due to --skip)", scan.score);


### PR DESCRIPTION
I happened to be looking at a cli  report output and noticed  the URL didn't work  anymore  (likely related to new web-tech underneath), this  should fix it.